### PR TITLE
Updated makefile to include 'copy' target and use debug build for em_proxy binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ em_proxy.h
 /em_proxy.xcframework
 /em_proxy.xcframework.zip
 /include
+*.a

--- a/Makefile
+++ b/Makefile
@@ -4,51 +4,74 @@ add_targets:
 	@echo "add_targets"
 	rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios
 
-build:
+
+compile:
 	@echo "build aarch64-apple-ios"
-	@cargo build --release --target aarch64-apple-ios
+	@# @cargo build --release --target aarch64-apple-ios
+	@cargo build --target aarch64-apple-ios
 	@echo "lipo"
-	@lipo -create \
+	@# @lipo -create \
 		-output target/lib$(TARGET)-ios.a \
 		target/aarch64-apple-ios/release/lib$(TARGET).a
+	@lipo -create \
+		-output target/lib$(TARGET)-ios.a \
+		target/aarch64-apple-ios/debug/lib$(TARGET).a
 
 	@echo "build aarch64-apple-ios-sim"
-	@cargo build --release --target aarch64-apple-ios-sim
+	@# @cargo build --release --target aarch64-apple-ios-sim
+	@cargo build --target aarch64-apple-ios-sim
 
 	@echo "build x86_64-apple-ios"
-	@cargo build --release --target x86_64-apple-ios
+	@# @cargo build --release --target x86_64-apple-ios
+	@cargo build --target x86_64-apple-ios
 
-	@lipo -create \
+	@# @lipo -create \
 		-output target/lib$(TARGET)-sim.a \
 		target/aarch64-apple-ios-sim/release/lib$(TARGET).a \
 		target/x86_64-apple-ios/release/lib$(TARGET).a
+	@lipo -create \
+		-output target/lib$(TARGET)-sim.a \
+		target/aarch64-apple-ios-sim/debug/lib$(TARGET).a \
+		target/x86_64-apple-ios/debug/lib$(TARGET).a
+
+copy:
+	@echo "copying binaries:"
+	@if [ -d "target" ]; then \
+		echo "    target/lib$(TARGET)-sim.a -> lib${TARGET}-sim.a"; \
+		cp "target/lib$(TARGET)-sim.a" "lib${TARGET}-sim.a"; \
+		echo "    target/lib$(TARGET)-ios.a -> lib${TARGET}-ios.a"; \
+		cp "target/lib$(TARGET)-ios.a" "lib${TARGET}-ios.a"; \
+	fi
+
+build: compile copy
 
 clean:
 	@echo "clean"
 	@if [ -d "include" ]; then \
 		echo "cleaning include"; \
-        rm -r include; \
-    fi
+		rm -r include; \
+	fi
 	@if [ -d "target" ]; then \
 		echo "cleaning target"; \
-        rm -r target; \
-    fi
+		rm -r target; \
+	fi
 	@if [ -d "$(TARGET).xcframework" ]; then \
 		echo "cleaning $(TARGET).xcframework"; \
-        rm -r $(TARGET).xcframework; \
-    fi
+		rm -r $(TARGET).xcframework; \
+	fi
 	@if [ -f "$(TARGET).xcframework.zip" ]; then \
 		echo "cleaning $(TARGET).xcframework.zip"; \
-        rm $(TARGET).xcframework.zip; \
-    fi
+		rm $(TARGET).xcframework.zip; \
+	fi
+	@rm -f *.a 
 
 xcframework: build
 	@echo "xcframework"
 
 	@if [ -d "include" ]; then \
 		echo "cleaning include"; \
-        rm -rf include; \
-    fi
+		rm -rf include; \
+	fi
 	@mkdir include
 	@mkdir include/$(TARGET)
 	@cp $(TARGET).h include/$(TARGET)
@@ -56,7 +79,7 @@ xcframework: build
 
 	@if [ -d "$(TARGET).xcframework" ]; then \
 		echo "cleaning $(TARGET).xcframework"; \
-	    rm -rf $(TARGET).xcframework; \
+		rm -rf $(TARGET).xcframework; \
 	fi
 	@xcodebuild \
 			-create-xcframework \
@@ -71,8 +94,8 @@ xcframework_frameworks: build
 
 	@if [ -d "include" ]; then \
 		echo "cleaning include"; \
-        rm -rf include; \
-    fi
+		rm -rf include; \
+	fi
 	@mkdir include
 	@mkdir include/$(TARGET)
 	@cp $(TARGET).h include/$(TARGET)
@@ -80,16 +103,16 @@ xcframework_frameworks: build
 
 	@if [ -d "target/ios" ]; then \
 		echo "cleaning target/ios"; \
-        rm -rf target/ios; \
-    fi
+		rm -rf target/ios; \
+	fi
 	@mkdir target/ios
 	@mkdir target/ios/$(TARGET).framework
 	@mkdir target/ios/$(TARGET).framework/Headers
 
 	@if [ -d "target/sim" ]; then \
 		echo "cleaning target/sim"; \
-        rm -rf target/sim; \
-    fi
+		rm -rf target/sim; \
+	fi
 	@mkdir target/sim
 	@mkdir target/sim/$(TARGET).framework
 	@mkdir target/sim/$(TARGET).framework/Headers
@@ -108,8 +131,8 @@ xcframework_frameworks: build
 
 	@if [ -d "$(TARGET).xcframework" ]; then \
 		echo "cleaning $(TARGET).xcframework"; \
-        rm -rf $(TARGET).xcframework; \
-    fi
+		rm -rf $(TARGET).xcframework; \
+	fi
 	@xcodebuild -create-xcframework \
 			-library target/sim/$(TARGET).framework \
 			-headers include/ \
@@ -121,6 +144,6 @@ zip: xcframework
 	@echo "zip"
 	@if [ -f "$(TARGET).xcframework.zip" ]; then \
 		echo "cleaning $(TARGET).xcframework.zip"; \
-        rm $(TARGET).xcframework.zip; \
-    fi
+		rm $(TARGET).xcframework.zip; \
+	fi
 	zip -r $(TARGET).xcframework.zip $(TARGET).xcframework


### PR DESCRIPTION
- commit is self-explanatory.
- debug build is enabled since, sidestore 0.5.x is still in beta.

NOTE: libem_proxy.a for iOS target has been renamed to libem_proxy-ios.a
Corresponding change needs to be made in SideStore project when using em_proxy generated static libs.
